### PR TITLE
Some necessary updates for PayPal integration:

### DIFF
--- a/src/UnifiedPayment/PayPalPaymentGateway.php
+++ b/src/UnifiedPayment/PayPalPaymentGateway.php
@@ -62,6 +62,19 @@ class PayPalPaymentGateway implements UnifiedPaymentGateway
     }
 
     /**
+     * @method executePaymentIntent
+     * @param string $paymentId Payment ID for the payment provider.
+     * @param string $payerId Payer ID for the payment provider.
+     * @description Capture a payment intent with the payment provider.
+     * @since 1.0.0
+     */
+    public function executePaymentIntent($paymentId, $payerId)
+    {
+        return $this->payPalClient->executePayment($paymentId, $payerId);
+    }
+
+
+    /**
      * @method refundPayment
      * @param string $paymentId Payment ID for the payment provider.
      * @param array $refundData Refund data for the payment provider.

--- a/src/UnifiedPayment/UnifiedPaymentClient.php
+++ b/src/UnifiedPayment/UnifiedPaymentClient.php
@@ -24,7 +24,7 @@ class UnifiedPaymentClient
      * @description The payment gateway for the unified payment client.
      * @since 1.0.0
      */
-    private $paymentGateway;
+    public $paymentGateway;
 
     /**
      * @method __construct


### PR DESCRIPTION
1. PayPal API v1 createPayment returns a state of created. It requires a subsequent execute call to return a state of approved. Therefore, a new executePayment method is needed.
2. PayPal and Stripe operations can be refined using different gateways. Therefore, public UnifiedPaymentClient.paymentGateway is required.
3. For easier API access and debugging, a cURL proxy configuration option should be added for PayPal.